### PR TITLE
Fix compatibility for Ubuntu Xenial

### DIFF
--- a/apt-stow
+++ b/apt-stow
@@ -178,7 +178,7 @@ main()
 			mkdir -p "$STOWTARGET"
 
 			mv "$curdir" "$STOWDIR/stow-tools/usr/bin"
-			env BOOTSTRAPSTOW="$STOWDIR/stow-tools/usr/bin/stow" "$STOWDIR/stow-tools/usr/bin/$(basename $0)" install stow
+			env BOOTSTRAPSTOW="$STOWDIR/stow-tools/usr/bin/stow" PERL5LIB="$STOWDIR/stow/usr/share/perl5" "$STOWDIR/stow-tools/usr/bin/$(basename $0)" install stow
 
 			if ! grep "STOWDIR" $HOME/.bashrc >/dev/null 2>/dev/null; then
 				echo "export STOWDIR=\"$STOWDIR\"" >> $HOME/.bashrc

--- a/bashrc-stow
+++ b/bashrc-stow
@@ -28,6 +28,7 @@ while getopts ":s:f:g:d" arg; do
 		d) # Defaults
 			$0 PATH usr/bin usr/sbin
 			$0 LD_LIBRARY_PATH usr/lib usr/lib/x86_64-linux-gnu
+			$0 PERL5LIB usr/share/perl5
 			$0 -fI -g "" CPPFLAGS usr/include
 			$0 -fL -g "" LDFLAGS usr/lib usr/lib/x86_64-linux-gnu
 			exit 0


### PR DESCRIPTION
After upgrading to ubuntu xenial and upgrading stow, the tool no longer worked since stow no longer worked. It now installs and requires itself as a perl module, rather than having everything in the one file. This patch augments the perl module search path so that things work again.